### PR TITLE
Fixes controlled vocab links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ruby:2.6.3
+
+WORKDIR /srv/pbcore-av-metadata
+
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+CMD jekyll serve --host 0.0.0.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
-ruby '2.5.1'
+ruby '2.6.3'
 # Hello! This is where you manage which Jekyll version is used to run.
 # When you want to use a different version, change it below, save the
 # file and run `bundle install`. Run Jekyll with `bundle exec`, like so:

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,12 +2,15 @@
   <meta name="viewport" content="width=device-width">
   <nav class="primary_nav_container navbar navbar-expand-xl navbar-expand-lg navbar-expand-md navbar-expand-sm navbar-expand-xs navbar-light bg-light">
 
+    <div class="language-selector">
+      <a href="http://pbcore.org{{ page.url }}">View in English</a>
+    </div>
+
     <div class="navbar-collapse" id="navbarNavDropdown">
 
       <div class="pbcore-logo" style="width: 100%;">
         <a href="/"><img class="pbcore-logo-img" src="/assets/images/pbcore-logo.png" alt=""></a>
       </div>
-
 
       <ul class="navbar-nav" style="width: 100%;">
 

--- a/_includes/vocab_sidebar.html
+++ b/_includes/vocab_sidebar.html
@@ -6,7 +6,7 @@
 
   {% for item in site.data.vocabs %}
     <h5>
-      <a href="{{item.url}}">{{item.name}}</a>
+      <a href="{{site.url}}{{item.url}}">{{item.name}}</a>
     </h5>
   {% endfor %}
 </nav>

--- a/assets/css/styles.scss
+++ b/assets/css/styles.scss
@@ -1221,3 +1221,14 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX*/
 .nav-underline-grey {
   border-bottom: 5px solid $dark-grey
 }
+
+.language-selector {
+  position: absolute;
+  top: 0;
+  right: 0;
+  margin: 1em 1em 0 0;
+
+  a {
+    font-size: 1em;
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3'
+services:
+  site:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - $PWD:/srv/pbcore-av-metadata


### PR DESCRIPTION
* Ensures controlled vocab links stay on Spanish version of site.
* Adds link to English site

Also:
* Upgrades Ruby version 2.5.1 => 2.6.3.
* Adds Dockerfile and docker-compose.yml confing for running dev server locally.
  * Run `docker compose up` to serve site locally at http://0.0.0.0:4000

Closes #5, closes #6.